### PR TITLE
Use is_a? String instead of model_name to track participants

### DIFF
--- a/lib/field_test/participant.rb
+++ b/lib/field_test/participant.rb
@@ -1,7 +1,7 @@
 module FieldTest
   class Participant
     def self.standardize(participants)
-      Array(participants).map { |v| v.respond_to?(:model_name) ? "#{v.model_name.name}:#{v.id}" : v.to_s }
+      Array(participants).map { |v| v.is_a?(String) ? v.to_s : "#{v.class.name}:#{v.id}" }
     end
   end
 end


### PR DESCRIPTION
I was having some issues (on Rails 4.0.13) with the use of `model_name` in participant.rb because, at least for me, `User.first.model_name` is not a method (but `User.model_name` is). So for my app, `membership.participant` was getting set to something like `#<User:0x007ff4d0116878>` (instead of `User:257`), which FieldTest then failed to recognize on each new request. The final result was that FieldTest failed to recognize any logged in user as the same user, and considered them a new participant on each request. This simple one-line change fixed the problem for me, which just checks if the participant is a string or not. I'm assuming that this always works because the cooke-based participants are always strings, and otherwise, it would be a model that you're tracking. Also, just calling `v.class.name` works with any Ruby object.

I hope this fix was for more than just myself, but I needed this to get it working!