### PR TITLE
Add support for tenants and scheduling tests based on started/ended_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.3
+
+- Added support for tenants
+- Enable/disable experiments based on started_at and ended_at
+
 ## 0.2.2
 
 - Added support for Rails 5.1

--- a/lib/field_test/version.rb
+++ b/lib/field_test/version.rb
@@ -1,3 +1,3 @@
 module FieldTest
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
* Support for optional tenants (used with Apartment gem)
* Control scheduling of experiments using existing started_at/ended_at attributes