### PR TITLE
Includes memberships without an event to correctly count participants

### DIFF
--- a/lib/field_test/experiment.rb
+++ b/lib/field_test/experiment.rb
@@ -105,7 +105,7 @@ module FieldTest
         sql =
           relation.joins("LEFT JOIN field_test_events ON field_test_events.field_test_membership_id = field_test_memberships.id")
             .select("variant, COUNT(DISTINCT participant) AS participated, COUNT(DISTINCT field_test_membership_id) AS converted")
-            .where(field_test_events: {name: goal})
+            .where(field_test_events: { name: [goal, nil] })
 
         FieldTest::Membership.connection.select_all(sql).each do |row|
           data[[row["variant"], true]] = row["converted"].to_i


### PR DESCRIPTION
The join table created by the left join between `field_test_memberships` and `field_test_events` will not contain an event name for participants who did not convert and therefore do not have an associated event.

Including `nil` in the portion of the query used to scope to a given event name ensures that we will also include participants who did not convert.

Resolves https://github.com/ankane/field_test/issues/3.

Thanks for you work on this gem @ankane -- let us know if there's anything else we can do, or if you'd rather take this in a different direction.