### PR TITLE
Make event names unique per membership_id

### DIFF
--- a/app/models/field_test/event.rb
+++ b/app/models/field_test/event.rb
@@ -3,6 +3,6 @@ module FieldTest
     self.table_name = "field_test_events"
 
     belongs_to :field_test_membership, class_name: "FieldTest::Membership"
-    validates :name, presence: true
+    validates :name, presence: true, uniqueness: { scope: :field_test_membership_id }
   end
 end

--- a/lib/field_test/experiment.rb
+++ b/lib/field_test/experiment.rb
@@ -69,10 +69,8 @@ module FieldTest
         end
 
         if use_events?
-          FieldTest::Event.create!(
-            name: goal,
-            field_test_membership_id: membership.id
-          )
+          e = { name: goal, field_test_membership_id: membership.id }
+          FieldTest::Event.create!(e) unless FieldTest::Event.exists?(e)
         end
 
         true


### PR DESCRIPTION
Small bug, but if you (accidentally) convert the same goal, for the same user, twice, then calculations start breaking, as you might have 1 participant but 2 conversions, aka -1 members in the "didn't convert" group, and other wonky stuff. 

Since nobody should be allowed to convert twice I figured it would be nice to add a simple validation preventing this behavior.