### PR TITLE
Allow manual "upgrade" of participant strings

### DIFF
--- a/app/models/field_test/membership.rb
+++ b/app/models/field_test/membership.rb
@@ -5,7 +5,7 @@ module FieldTest
     has_many :events, class_name: "FieldTest::Event"
 
     validates :participant, presence: true
-    validates :experiment, presence: true
+    validates :experiment, presence: true, uniqueness: { scope: :participant }
     validates :variant, presence: true
   end
 end

--- a/lib/field_test/helpers.rb
+++ b/lib/field_test/helpers.rb
@@ -31,6 +31,19 @@ module FieldTest
       exp.convert(participants, goal: options[:goal])
     end
 
+    def upgrade_field_test_memberships(options = {})
+      # Upgrade any current memberships to their preferred participant
+      participants = field_test_participants(options)
+      not_upgraded_memberships =
+        FieldTest::Membership
+        .where(participant: participants)
+        .where.not(participant: participants.first)
+
+      not_upgraded_memberships.each do |membership|
+        membership.update participant: participants.first
+      end
+    end
+
     def field_test_experiments(options = {})
       participants = field_test_participants(options)
       memberships = FieldTest::Membership.where(participant: participants).group_by(&:participant)


### PR DESCRIPTION
This simple method allows you to manually "upgrade" your participant strings. The use case I had was that I wanted to "upgrade" all memberships to have the participant "User:35739" after a user signed in to my website, for any experiments they were part of before logging in. This already happens if I try to ask about a specific experiment with `experiment.variant` (the Membership is upgraded from a uuid participant to "User:35739", but that only happens if I'm actually checking for an experiment. 

This method can be easily added anywhere after users sign in/sign up for an account, and it automatically "upgrades" all of their Memberships to the preferred "User:35739" format, which makes tracking those users down the line much easier.