### PR TITLE
exclude arbitrary ips

### DIFF
--- a/lib/field_test.rb
+++ b/lib/field_test.rb
@@ -30,6 +30,16 @@ module FieldTest
     @config ||= YAML.load(ERB.new(File.read(config_path)).result)
   end
 
+  def self.exclude_ips?
+    config["exclude"] && config["exclude"]["ips"]
+  end
+
+  def self.excluded_ips
+    return [] unless exclude_ips?
+
+    config["exclude"]["ips"]
+  end
+
   def self.exclude_bots?
     config["exclude"] && config["exclude"]["bots"]
   end

--- a/lib/field_test/helpers.rb
+++ b/lib/field_test/helpers.rb
@@ -16,6 +16,10 @@ module FieldTest
           options[:exclude] = Browser.new(request.user_agent).bot?
         end
 
+        if FieldTest.exclude_ips?
+          options[:exclude] ||= FieldTest.excluded_ips.any? { |ip| ip == request.remote_ip }
+        end
+
         options[:ip] = request.remote_ip
         options[:user_agent] = request.user_agent
       end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -51,4 +51,11 @@ class ControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal 0, FieldTest::Membership.count
   end
+
+  def test_exclude_ips
+    get users_url, headers: {"HTTP_X_FORWARDED_FOR" => "123.4.5.6"}
+    assert_response :success
+
+    assert_equal 0, FieldTest::Membership.count
+  end
 end

--- a/test/internal/config/field_test.yml
+++ b/test/internal/config/field_test.yml
@@ -25,3 +25,5 @@ experiments:
     closed: true
 exclude:
   bots: true
+  ips:
+    - 123.4.5.6


### PR DESCRIPTION
Addresses https://github.com/ankane/field_test/issues/19

Cool done. I assume if I set this configuration now it'll only apply going forward and not retroactively?