### PR TITLE
Corrects typo in the readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Run:
 
 ```sh
 rails generate field_test:install
-rails db:migrate
+rake db:migrate
 ```
 
 And mount the dashboard in your `config/routes.rb`:

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ You can set multiple goals for an experiment to track conversions at different p
 
 ```sh
 rails generate field_test:events
-rails db:migrate
+rake db:migrate
 ```
 
 And add to your config:


### PR DESCRIPTION
I'm just starting out to use the gem.  It looks like exactly what I need.  As I get started, I noticed a tiny typo, so thought I'd contribute a fix.  The command to apply the schema is `rake db:migrate` not `rails db:migrate` (though looking around now, perhaps newer versions of rails have added the newer command?)