### PR TITLE
Fix foreign_key for membership/event association

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,5 +425,6 @@ To get started with development:
 git clone https://github.com/ankane/field_test.git
 cd field_test
 bundle install
+bundle exec rake compile
 bundle exec rake test
 ```

--- a/app/models/field_test/membership.rb
+++ b/app/models/field_test/membership.rb
@@ -2,7 +2,7 @@ module FieldTest
   class Membership < ActiveRecord::Base
     self.table_name = "field_test_memberships"
 
-    has_many :events, class_name: "FieldTest::Event"
+    has_many :events, class_name: "FieldTest::Event", foreign_key: "field_test_membership_id"
 
     validates :participant, presence: true, if: -> { FieldTest.legacy_participants }
     validates :participant_id, presence: true, if: -> { !FieldTest.legacy_participants }

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -13,8 +13,6 @@ class ModelTest < Minitest::Test
       field_test_membership_id: membership.id
     )
 
-    puts "*** the sql"
-    puts membership.events.to_sql
     assert_equal membership, event.field_test_membership
     assert_equal 1, membership.events.count
     assert_equal event, membership.events.first

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -1,0 +1,22 @@
+require_relative "test_helper"
+
+class ModelTest < Minitest::Test
+  def setup
+    FieldTest::Membership.delete_all
+  end
+
+  def test_membership_with_event
+    experiment = FieldTest::Experiment.find(:landing_page)
+    membership = set_variant experiment, "page_a", "user123"
+    event = FieldTest::Event.create!(
+      name: "conversion",
+      field_test_membership_id: membership.id
+    )
+
+    puts "*** the sql"
+    puts membership.events.to_sql
+    assert_equal membership, event.field_test_membership
+    assert_equal 1, membership.events.count
+    assert_equal event, membership.events.first
+  end
+end


### PR DESCRIPTION
Adds the correct foreign_key for Membership has_many association.

Without this change, when you try to access membership.events, you get the following error:

```
ActiveRecord::StatementInvalid (PG::UndefinedColumn: ERROR:  column field_test_events.membership_id does not exist)
LINE 1: ...eld_test_events".* FROM "field_test_events" WHERE "field_tes...

```

Also updates README instructions about local development to include compile step.