### PR TITLE
Fix exclude option in #field_test helper method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.5.2 (unreleased)
 
 - Fixed error with `events` association
+- Fixed explicit exclusion by custom logic
 
 ## 0.5.1 (2021-09-22)
 

--- a/lib/field_test/helpers.rb
+++ b/lib/field_test/helpers.rb
@@ -13,7 +13,7 @@ module FieldTest
         end
 
         if FieldTest.exclude_bots?
-          options[:exclude] = Browser.new(request.user_agent).bot?
+          options[:exclude] ||= Browser.new(request.user_agent).bot?
         end
 
         options[:exclude] ||= FieldTest.excluded_ips.any? { |ip| ip.include?(request.remote_ip) }

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -45,6 +45,13 @@ class ControllerTest < ActionDispatch::IntegrationTest
     refute_includes response.body, "Button: bad"
   end
 
+  def test_custom_exclude_logic
+    get users_url("exclude" => "true")
+    assert_response :success
+
+    assert_equal 0, FieldTest::Membership.count
+  end
+
   def test_exclude_bots
     get users_url, headers: {"HTTP_USER_AGENT" => "Googlebot"}
     assert_response :success

--- a/test/internal/app/controllers/users_controller.rb
+++ b/test/internal/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ActionController::Base
   def index
-    @button_color = field_test(:button_color)
+    @button_color = field_test(:button_color, exclude: params[:exclude])
     field_test_converted(:button_color)
     @experiments = field_test_experiments
   end

--- a/test/internal/app/views/users/index.html.erb
+++ b/test/internal/app/views/users/index.html.erb
@@ -1,3 +1,3 @@
-<p>Button: <%= field_test(:button_color) %></p>
+<p>Button: <%= @button_color %></p>
 <p>Converted: <%= field_test_converted(:button_color) %></p>
 <p>Experiments: <%= field_test_experiments %></p>


### PR DESCRIPTION
First of all, thanks for this great gem!

This PR addresses an unexpected behaviour that I found recently. The [readme says here](https://github.com/ankane/field_test/blob/master/README.md#exclusions) that participants can be excluded by a custom logic, providing the `exclude` option, but it is overwritten by the exclusion check for bots later.

I prepared this PR from a monkey patch we use internally and also added a new API controller for tests as I think this use case fits better. Any feedback is appreciated on it!