### PR TITLE
Adding default if config["experiments"] is nil

### DIFF
--- a/lib/field_test/experiment.rb
+++ b/lib/field_test/experiment.rb
@@ -191,7 +191,7 @@ module FieldTest
     end
 
     def self.all
-      FieldTest.config["experiments"].map do |id, settings|
+      FieldTest.config.fetch("experiments", {}).map do |id, settings|
         FieldTest::Experiment.new(settings.merge(id: id.to_s))
       end
     end

--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -66,4 +66,8 @@ class ExperimentTest < Minitest::Test
     assert_equal ["red", "green", "blue"], experiment.variants
     assert_equal "red", experiment.control
   end
+
+  def test_all_works_even_with_no_configured_experiments
+    assert_equal [], FieldTest::Experiment.all
+  end
 end


### PR DESCRIPTION
This fixes the case in which there are no config/field_tests.yml
experiments.  Prior to this fix, `FieldTest.config["experiments"].map`
would raise a NoMethodError for .each on nil.