### PR TITLE
Coalesce participant_type since it can be NULL

### DIFF
--- a/lib/field_test/experiment.rb
+++ b/lib/field_test/experiment.rb
@@ -114,7 +114,7 @@ module FieldTest
           elsif adapter_name =~ /postg/i # postgres
             "(participant_type, participant_id)"
           elsif adapter_name =~ /mysql/i
-            "participant_type, participant_id"
+            "COALESCE(participant_type, ''), participant_id"
           else
             # not perfect, but it'll do
             "COALESCE(participant_type, '') || ':' || participant_id"


### PR DESCRIPTION
Mysql seems to throw out rows with a null participant_type when
counting. Using coalesce with an empty string, mysql counts them again.