### PR TITLE
Use multiple columns for counting in mysql to avoid bug

### DIFF
--- a/lib/field_test/experiment.rb
+++ b/lib/field_test/experiment.rb
@@ -113,9 +113,10 @@ module FieldTest
             :participant
           elsif adapter_name =~ /postg/i # postgres
             "(participant_type, participant_id)"
+          elsif adapter_name =~ /mysql/i
+            "COALESCE(participant_type, ''), participant_id"
           else
             # SQLite supports single column
-            # MySQL supports multiple columns, but none can be NULL
             "COALESCE(participant_type, '') || ':' || participant_id"
           end
 


### PR DESCRIPTION
When concatenating the fields into one column to count, mysql(5.7) is returning
incorrect counts. Instead revert to using multi coulmn counting with a
non null fallback.

correct -> 
```ruby
FieldTest::Experiment.all.first.events.
  merge(FieldTest::Experiment.all.first.memberships.group(:variant)).
  where(field_test_events: {name: "my_goal"}).
  distinct.count("COALESCE(participant_type, ''), participant_id")
=> {"variant1"=>33, "variant2"=>41}
```
wrong -> 
```ruby
FieldTest::Experiment.all.first.events.
  merge(FieldTest::Experiment.all.first.memberships.group(:variant)).
  where(field_test_events: {name: "my_goal"}).
  distinct.count("COALESCE(participant_type, '') || ':' || participant_id")
=> {"variant1"=>2, "variant2"=>2}
```