### PR TITLE
Configurable bot detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,16 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+By default field_test uses the Browser gem to detect bots based on the user agent string of the request. You can override this behavior with your own logic by overriding the `field_test_bot?` method in your controller.
+
+```ruby
+class ApplicationController < ActionController::Base
+  def field_test_bot?
+    request.user_agent == "Test" || super
+  end
+end
+```
+
 ## Dashboard Security
 
 #### Devise

--- a/lib/field_test/controller.rb
+++ b/lib/field_test/controller.rb
@@ -72,5 +72,9 @@ module FieldTest
 
       participants
     end
+
+    def field_test_bot?
+      Browser.new(request.user_agent).bot?
+    end
   end
 end

--- a/lib/field_test/helpers.rb
+++ b/lib/field_test/helpers.rb
@@ -13,7 +13,7 @@ module FieldTest
         end
 
         if FieldTest.exclude_bots?
-          options[:exclude] ||= Browser.new(request.user_agent).bot?
+          options[:exclude] ||= field_test_bot?
         end
 
         options[:exclude] ||= FieldTest.excluded_ips.any? { |ip| ip.include?(request.remote_ip) }


### PR DESCRIPTION
As bots have become more sophisticated so too has our ability to detect them. User agent comparison is good enough for most cases but better methods are available.

This change allows users to override the default bot detection behavior simply by overloading the field_test_bot? method in their own controllers very similar to how customizing field_test_participant works.