### PR TITLE
Add belongs_to :participant to Membership

### DIFF
--- a/app/models/field_test/membership.rb
+++ b/app/models/field_test/membership.rb
@@ -4,6 +4,10 @@ module FieldTest
 
     has_many :events, class_name: "FieldTest::Event", foreign_key: "field_test_membership_id"
 
+    unless FieldTest.legacy_participants
+      belongs_to :participant, polymorphic: true, optional: true
+    end
+
     validates :participant, presence: true, if: -> { FieldTest.legacy_participants }
     validates :participant_id, presence: true, if: -> { !FieldTest.legacy_participants }
     validates :experiment, presence: true

--- a/lib/field_test/controller.rb
+++ b/lib/field_test/controller.rb
@@ -17,7 +17,9 @@ module FieldTest
       Array(participants[1..-1]).each do |participant|
         # can do this in single query once legacy_participants is removed
         FieldTest::Membership.where(participant.where_values).each do |membership|
-          membership.participant = preferred.participant if membership.respond_to?(:participant=)
+          if FieldTest.legacy_participants
+            membership.participant = preferred.participant if membership.respond_to?(:participant=)
+          end
           membership.participant_type = preferred.type if membership.respond_to?(:participant_type=)
           membership.participant_id = preferred.id if membership.respond_to?(:participant_id=)
           membership.save!

--- a/lib/field_test/experiment.rb
+++ b/lib/field_test/experiment.rb
@@ -45,7 +45,9 @@ module FieldTest
       participant = participants.first
 
       # upgrade to preferred participant
-      membership.participant = participant.participant if membership.respond_to?(:participant=)
+      if FieldTest.legacy_participants
+        membership.participant = participant.participant if membership.respond_to?(:participant=)
+      end
       membership.participant_type = participant.type if membership.respond_to?(:participant_type=)
       membership.participant_id = participant.id if membership.respond_to?(:participant_id=)
 

--- a/lib/field_test/participant.rb
+++ b/lib/field_test/participant.rb
@@ -15,7 +15,11 @@ module FieldTest
     end
 
     def participant
-      [type, id].compact.join(":")
+      if FieldTest.legacy_participants
+        [type, id].compact.join(":")
+      else
+        type.constantize.find(id) if type.present? && id.present?
+      end
     end
 
     def where_values


### PR DESCRIPTION
# Description

Legacy participants were stored as strings on the membership. In contrast, non-legacy systems store a polymorphic id and type.

As a result, in non-legacy systems, `Membership` no longer responds to `#participant`. However, we still want it to respond and return the ActiveRecord object.