### PR TITLE
Add content security policy nonce to dashboard headers

### DIFF
--- a/app/views/field_test/experiments/_experiments.html.erb
+++ b/app/views/field_test/experiments/_experiments.html.erb
@@ -20,10 +20,10 @@
       <thead>
         <tr>
           <th>Variant</th>
-          <th style="width: 20%;">Participants</th>
-          <th style="width: 20%;">Conversions</th>
-          <th style="width: 20%;">Conversion Rate</th>
-          <th style="width: 20%;">Prob Winning</th>
+          <th class="width-20">Participants</th>
+          <th class="width-20">Conversions</th>
+          <th class="width-20">Conversion Rate</th>
+          <th class="width-20">Prob Winning</th>
         </tr>
       </thead>
       <tbody>

--- a/app/views/field_test/experiments/show.html.erb
+++ b/app/views/field_test/experiments/show.html.erb
@@ -14,9 +14,9 @@
   <thead>
     <tr>
       <th>Participant</th>
-      <th style="width: 20%;">Variant</th>
-      <th style="width: 20%;">Converted</th>
-      <th style="width: 20%;">Started</th>
+      <th class="width-20">Variant</th>
+      <th class="width-20">Converted</th>
+      <th class="width-20">Started</th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/field_test/participants/show.html.erb
+++ b/app/views/field_test/participants/show.html.erb
@@ -10,9 +10,9 @@
   <thead>
     <tr>
       <th>Experiment</th>
-      <th style="width: 20%;">Variant</th>
-      <th style="width: 20%;">Converted</th>
-      <th style="width: 20%;">Started</th>
+      <th class="width-20">Variant</th>
+      <th class="width-20">Converted</th>
+      <th class="width-20">Started</th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/layouts/field_test/application.html.erb
+++ b/app/views/layouts/field_test/application.html.erb
@@ -3,7 +3,7 @@
     <title>Field Test</title>
 
     <%= csp_meta_tag %>
-    <style nonce="<%= nonce %>">
+    <style>
       body {
         margin: 0;
         padding: 20px;

--- a/app/views/layouts/field_test/application.html.erb
+++ b/app/views/layouts/field_test/application.html.erb
@@ -3,7 +3,7 @@
     <title>Field Test</title>
 
     <%= csp_meta_tag %>
-    <style>
+    <style nonce="<%= nonce %>">
       body {
         margin: 0;
         padding: 20px;

--- a/app/views/layouts/field_test/application.html.erb
+++ b/app/views/layouts/field_test/application.html.erb
@@ -79,6 +79,10 @@
         padding-left: 10px;
         padding-right: 10px;
       }
+
+      .width-20 {
+        width: 20%;
+      }
     </style>
   </head>
   <body>

--- a/app/views/layouts/field_test/application.html.erb
+++ b/app/views/layouts/field_test/application.html.erb
@@ -2,6 +2,7 @@
   <head>
     <title>Field Test</title>
 
+    <%= csp_meta_tag %>
     <style>
       body {
         margin: 0;

--- a/app/views/layouts/field_test/application.html.erb
+++ b/app/views/layouts/field_test/application.html.erb
@@ -3,7 +3,7 @@
     <title>Field Test</title>
 
     <%= csp_meta_tag %>
-    <style>
+    <style nonce="<%= content_security_policy_nonce %>">
       body {
         margin: 0;
         padding: 20px;


### PR DESCRIPTION
Allows the styles to load on sites that don't allow `unsafe-inline` styles in their content security policy by adding a nonce to the style tag and adds a csp_meta tag. 

Also replaces the `width: 20%;` inline styles with a CSS class defined in the header.